### PR TITLE
Fixing bug which causes empty element when ampersand is used

### DIFF
--- a/Transport/XmlDataTransportDecorator.php
+++ b/Transport/XmlDataTransportDecorator.php
@@ -67,7 +67,8 @@ class XmlDataTransportDecorator implements Transport
                         $value = $value->format('Y-m-d H:i:s');
                     }
                 }
-                $keyValue = $row->addChild('FL', $value);
+                $keyValue = $row->addChild('FL');
+                $keyValue[0] = $value;
                 $keyValue->addAttribute('val', $key);
             }
         }


### PR DESCRIPTION
Due to design flaw in SimpleXML, ampersands will not be escape when using addChild. You end up with an empty element and you get this error:

`Warning: SimpleXMLElement::addChild(): unterminated entity reference`

It's discussed in the PHP docs: http://php.net/manual/en/simplexmlelement.addchild.php#112204

I've provided a simple workaround which avoids the problem