### PR TITLE
Allow choosing Zoho realm when constructing, letting EU users connect.

### DIFF
--- a/ZohoCRMClient.php
+++ b/ZohoCRMClient.php
@@ -19,7 +19,7 @@ class ZohoCRMClient implements LoggerAwareInterface
     /** @var LoggerInterface */
     private $logger;
 
-    public function __construct($module, $authToken)
+    public function __construct($module, $authToken, $realm = 'com')
     {
         $this->module = $module;
 
@@ -31,7 +31,7 @@ class ZohoCRMClient implements LoggerAwareInterface
                         $authToken,
                         new Transport\BuzzTransport(
                             new \Buzz\Browser(new \Buzz\Client\Curl()),
-                            'https://crm.zoho.com/crm/private/xml/'
+                            sprintf('https://crm.zoho.%s/crm/private/xml/', $realm)
                         )
                     )
                 );


### PR DESCRIPTION
This change adds an optional third parameter to the constructor, which specifies the Zoho realm to connect to. Users on the EU realm currently cannot connect to the .com URL, and as such would need to set up a custom transport.