### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ $client = new ZohoCRMClient('Leads', $transport);
 
 ## Implemented Calls
 At the moment only the following calls are supported
-- getRecords
-- getRecordById
-- insertRecords
-- updateRecords
-- getFields
+- [getRecords](https://www.zoho.eu/crm/help/api/getrecords.html)
+- [getRecordById](https://www.zoho.eu/crm/help/api/getrecordbyid.html) 
+- [insertRecords](https://www.zoho.eu/crm/help/api/insertrecords.html)
+- [updateRecords](https://www.zoho.eu/crm/help/api/updaterecords.html)
+- [getFields](https://www.zoho.eu/crm/help/api/getfields.html)
+- [searchResults](https://www.zoho.eu/crm/help/api/searchrecords.html)
 
 It is rather easy to add new calls, look at one of the classes in the Request dir for examples.
 After the Request class is made it might be necessary to alter the parsing of the response XML in the XmlDataTransportDecorator class.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,60 @@ At the moment only the following calls are supported
 
 It is rather easy to add new calls, look at one of the classes in the Request dir for examples.
 After the Request class is made it might be necessary to alter the parsing of the response XML in the XmlDataTransportDecorator class.
+
+## More examples
+
+### insertRecords()
+
+```php
+use Christiaan\ZohoCRMClient\ZohoCRMClient;
+
+$client = new ZohoCRMClient('Contacts', 'yourAuthKey');
+
+$records = $client
+            ->insertRecords()
+            ->addRecord([
+                'Email' => 'john@example.com',
+                'First Name' => 'John'
+            ])
+            ->request();
+```
+
+Optionally, you can add `onDuplicateUpdate()` or `onDuplicateError()` to the chain, before `request()`, to instruct Zoho to either update or fail on duplicated records.
+Duplicate checking depends on the module being targeted, see the list in the [Zoho documentation](https://www.zoho.eu/crm/help/api/insertrecords.html#Duplicate_Check_Fields).
+
+The `$records` array will contain an entry for each record you have tried to create, which on success will contain the ID of the new (or updated) record.
+
+### updateRecords()
+
+```php
+use Christiaan\ZohoCRMClient\ZohoCRMClient;
+
+$client = new ZohoCRMClient('Contacts', 'yourAuthKey');
+
+$records = $client
+            ->updateRecords()
+            ->addRecord([
+                'Id' => '(ID returned from insert, search, ...)'
+                'Last Name' => 'Smith'
+            ])
+            ->request();
+```
+
+Specifying the ID per record is necessary when updating multiple records. Alternatively, you may call `id()` to set the ID if you are only updating a single record. Setting the ID per record works in either case.
+
+### searchResults()
+
+```php
+use Christiaan\ZohoCRMClient\ZohoCRMClient;
+
+$client = new ZohoCRMClient('Contacts', 'yourAuthKey');
+
+$records = $client
+            ->searchRecords()
+            ->criteria('Email:john@example.com')
+            ->request();
+```
+
+See the [Zoho documentation](https://www.zoho.eu/crm/help/api/searchrecords.html) for the full explanation of how to write the criteria.
+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ echo 'Content: ' . print_r($records, true) . PHP_EOL;
 
 ```
 
+### Choosing a different Zoho realm
+
+ZohoCRMClient will by default connect to the API at `crm.zoho.com`. If you wish to connect to a different one, you can supply the TLD as the third parameter to the constructor. For example, customer on the EU realm should instantiate the client like this:
+
+``` php
+$client = new ZohoCRMClient('Leads', 'yourAuthKey', 'eu');
+```
+
 ## Using custom transport settings to enable logging
 ```php
 $buzzTransport = new BuzzTransport(


### PR DESCRIPTION
Some additions to the readme:

1. Description of how to use a different realm, for example `.eu` instead of `.com`.
2. Added `searchResults` to the list of supported calls.
3. Added examples for `insertRecords`, `updateRecords`, and `searchRecords` which would close this issue: https://github.com/christiaan/zohocrmclient/issues/12 .
