### PR TITLE
Made all transports logger aware, chaning setLogger to any inner transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,22 @@ $records = $client->getRecords()
     ->request();
 
 echo 'Content: ' . print_r($records, true) . PHP_EOL;
-
 ```
 
-## Using custom transport settings to enable logging
+### Enabling logging
+
+You can enable logging by adding the following line after instantiating the client:
+
+```php
+$client->setLogger($myPsrLogger);
+```
+
+The logger should implement the PSR `LoggerInterface`. If the transport being used implements `LoggerAwareInterface`, this call will chaing to set the logger for the transport as well. The build in transport supports this.
+
+### Using custom transport
+
+If we wish, you can supply a custom transport class to ZohoCRMClient, as shown here:
+
 ```php
 $buzzTransport = new BuzzTransport(
     new \Buzz\Browser(new \Buzz\Client\Curl()),

--- a/Transport/AuthenticationTokenTransportDecorator.php
+++ b/Transport/AuthenticationTokenTransportDecorator.php
@@ -1,10 +1,13 @@
 <?php
 namespace Christiaan\ZohoCRMClient\Transport;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
 /**
  * Transport Decorator that transparently adds the authtoken param and scope param
  */
-class AuthenticationTokenTransportDecorator implements Transport
+class AuthenticationTokenTransportDecorator implements Transport, LoggerAwareInterface
 {
     private $authToken;
     private $transport;
@@ -21,5 +24,19 @@ class AuthenticationTokenTransportDecorator implements Transport
         $paramList['scope'] = 'crmapi';
 
         return $this->transport->call($module, $method, $paramList);
+    }
+
+    /**
+     * Sets a logger instance on the object.
+     *
+     * @param LoggerInterface $logger
+     *
+     * @return void
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        if ($this->transport instanceof LoggerAwareInterface) {
+            $this->transport->setLogger($logger);
+        }
     }
 }

--- a/Transport/XmlDataTransportDecorator.php
+++ b/Transport/XmlDataTransportDecorator.php
@@ -4,12 +4,14 @@ namespace Christiaan\ZohoCRMClient\Transport;
 use Christiaan\ZohoCRMClient\Exception;
 use Christiaan\ZohoCRMClient\Response;
 use Christiaan\ZohoCRMClient\ZohoError;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 
 /**
  * XmlDataTransportDecorator handles the XML communication with Zoho
  */
-class XmlDataTransportDecorator implements Transport
+class XmlDataTransportDecorator implements Transport, LoggerAwareInterface
 {
     /** @var Transport */
     private $transport;
@@ -44,6 +46,20 @@ class XmlDataTransportDecorator implements Transport
         $response = $this->transport->call($module, $method, $paramList);
 
         return $this->parse($response);
+    }
+
+    /**
+     * Sets a logger instance on the object.
+     *
+     * @param LoggerInterface $logger
+     *
+     * @return void
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        if ($this->transport instanceof LoggerAwareInterface) {
+            $this->transport->setLogger($logger);
+        }
     }
 
     /**

--- a/ZohoCRMClient.php
+++ b/ZohoCRMClient.php
@@ -47,6 +47,10 @@ class ZohoCRMClient implements LoggerAwareInterface
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+
+        if ($this->transport instanceof LoggerAwareInterface) {
+            $this->transport->setLogger($logger);
+        }
     }
 
     /**


### PR DESCRIPTION
Feel free to disagree with this one.

This change makes all the xTransport classes implement the LoggerAware interfaces. It further makes them chain the call to setLogger when they have an inner transport, and if that inner transport also implements LoggerAware.

It basically makes a call to `setLogger` on the main class chain to the current transport, when possible :)